### PR TITLE
Add JARs on classpath to the analysis cache

### DIFF
--- a/src/main/java/com/youdevise/fbplugins/tdd4fb/CustomCollections.java
+++ b/src/main/java/com/youdevise/fbplugins/tdd4fb/CustomCollections.java
@@ -1,0 +1,22 @@
+package com.youdevise.fbplugins.tdd4fb;
+
+import java.util.HashSet;
+import java.util.Set;
+
+
+class CustomCollections {
+    private CustomCollections() {}
+    
+    // Ideally a Predicate class would be used in this method, but a dependence on, say, guava, is unwarranted
+    static Set<String> splitByDelimiterAndFilterByRegex(String stringToBeSplit, String delimiter, String regex) {
+        Set<String> set = new HashSet<String>();
+        
+        for(String field : stringToBeSplit.split(delimiter)) {
+            if (field.matches(regex)) {
+                set.add(field);
+            }
+        }
+        
+        return set;
+    }
+}

--- a/src/test/java/com/youdevise/fbplugins/tdd4fb/CustomCollectionsTest.java
+++ b/src/test/java/com/youdevise/fbplugins/tdd4fb/CustomCollectionsTest.java
@@ -1,0 +1,27 @@
+package com.youdevise.fbplugins.tdd4fb;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class CustomCollectionsTest {
+    
+    @Test
+    public void splitByDelimiterAndFilterByRegexSplitsCorrectly() {
+        String string = "guice-3.0.jar:b.jar:c.class";
+        String delimiter = ":";
+        String regex = ".*\\.jar";
+        
+        Set<String> expectedSet = new HashSet<String>();
+        expectedSet.add("guice-3.0.jar");
+        expectedSet.add("b.jar");
+        
+        Set<String> actualSet = CustomCollections.splitByDelimiterAndFilterByRegex(string, delimiter, regex);
+        
+        assertEquals(expectedSet, actualSet);
+    }
+
+}


### PR DESCRIPTION
Hi,

I'm writing a Findbugs detector, https://github.com/tomfitzhenry/findbugs-guice , and am using test-driven-detectors4findbugs.

One of my detectors looks for interfaces that are annotated with annotations that are themselves annotated with com.google.inject.ScopeAnnotation. One such annotation is com.google.inject.Singleton and an example of an interface is https://github.com/tomfitzhenry/findbugs-guice/blob/master/src/test/benchmarks/uk/me/tom_fitzhenry/findbugs/guice/benchmarks/AnInterfaceWithAScopingAnnotation.java .

For this benchmark to be tested (e.g. https://github.com/tomfitzhenry/findbugs-guice/blob/master/src/test/java/uk/me/tom_fitzhenry/findbugs/guice/ScopingOnInterfacesDetectorTest.java#L32) Findbugs's analysis cache must be able to scan com.google.inject.Singleton (to see that it is annotated by com.google.inject.ScopeAnnotation).

I have three options:
    1. Implement com.google.inject.Singleton in my library (which I'd rather not do)
    2. Implement another annotation com.tom.MyScopeAnnotation, for example, and use that in benchmark instead of com.google.inject.Singleton (I'd prefer not to do that, so my benchmarks are more understandable. There are more guice users that understand Scopes simply in terms of Singleton, and not that it's possible to write your own Scope)
    3. Configure the analysis cache to scan JARs in the classpath.

Option 3 is my most preferred option and I have implemented that in this pull request.

Feel free, of course, to reject or offer feedback. :)

Tom
