### PR TITLE
support Detector2 interface. refs #8

### DIFF
--- a/src/main/java/com/youdevise/fbplugins/tdd4fb/DetectorAssert.java
+++ b/src/main/java/com/youdevise/fbplugins/tdd4fb/DetectorAssert.java
@@ -19,7 +19,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
-*/
+ */
 
 package com.youdevise.fbplugins.tdd4fb;
 
@@ -27,49 +27,84 @@ import static com.youdevise.fbplugins.tdd4fb.DetectorRunner.runDetectorOnClass;
 
 import org.hamcrest.Matcher;
 
-
 import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.Detector2;
+import edu.umd.cs.findbugs.DetectorToDetector2Adapter;
+import edu.umd.cs.findbugs.classfile.IAnalysisEngineRegistrar;
 
 public class DetectorAssert {
 
-	private static BugsReportedAsserter asserter = new BugsReportedAsserter();
+    private static BugsReportedAsserter asserter = new BugsReportedAsserter();
 
-	public static void assertBugReported(Class<?> classToTest, Detector detector, BugReporter bugReporter,
-			                             Matcher<BugInstance> bugInstanceMatcher) 
-	                                     throws Exception {
-		runDetectorOnClass(detector, classToTest, bugReporter);
-		asserter.assertBugReported(bugReporter, bugInstanceMatcher);
+    public static void assertBugReported(Class<?> classToTest,
+            Detector detector, BugReporter bugReporter,
+            Matcher<BugInstance> bugInstanceMatcher) throws Exception {
+        assertBugReported(classToTest, adapt(detector), bugReporter);
+    }
 
-	}
+    public static void assertAllBugsReported(Class<?> classToTest,
+            Detector detector, BugReporter bugReporter,
+            Matcher<BugInstance>... bugInstanceMatchers) throws Exception {
+        assertAllBugsReported(classToTest, adapt(detector), bugReporter,
+                bugInstanceMatchers);
+    }
 
-	public static void assertAllBugsReported(Class<?> classToTest, Detector detector, BugReporter bugReporter,
-			                                 Matcher<BugInstance>... bugInstanceMatchers) 
-	                                         throws Exception {
-		runDetectorOnClass(detector, classToTest, bugReporter);
-		asserter.assertAllBugsReported(bugReporter, bugInstanceMatchers);
-	}
+    public static void assertBugReported(Class<?> classToTest,
+            Detector detector, BugReporter bugReporter) throws Exception {
+        assertBugReported(classToTest, adapt(detector), bugReporter);
+    }
 
-	public static void assertBugReported(Class<?> classToTest, Detector detector, BugReporter bugReporter)
-			throws Exception {
-		runDetectorOnClass(detector, classToTest, bugReporter);
-		asserter.assertBugReported(bugReporter);
-	}
+    public static void assertNoBugsReported(Class<?> classToTest,
+            Detector detector, BugReporter bugReporter) throws Exception {
+        assertNoBugsReported(classToTest, adapt(detector), bugReporter);
+    }
 
-	public static void assertNoBugsReported(Class<?> classToTest, Detector detector, BugReporter bugReporter)
-			throws Exception {
-		runDetectorOnClass(detector, classToTest, bugReporter);
-		asserter.assertNoBugsReported(bugReporter);
+    public static BugReporter bugReporterForTesting() {
+        return TestingBugReporter.tddBugReporter();
+    }
 
-	}
+    public static Matcher<BugInstance> ofType(String type) {
+        return FindBugsMatchers.ofType(type);
+    }
 
-	public static BugReporter bugReporterForTesting() {
-		return TestingBugReporter.tddBugReporter();
-	}
+    public static void assertBugReported(Class<?> classToTest,
+            Detector2 detector, BugReporter bugReporter,
+            Matcher<BugInstance> bugInstanceMatcher) throws Exception {
+        runDetectorOnClass(detector, classToTest, bugReporter);
+        asserter.assertBugReported(bugReporter, bugInstanceMatcher);
+    }
 
-	public static Matcher<BugInstance> ofType(String type) {
-		return FindBugsMatchers.ofType(type);
-	}
+    public static void assertAllBugsReported(Class<?> classToTest,
+            Detector2 detector, BugReporter bugReporter,
+            Matcher<BugInstance>... bugInstanceMatchers) throws Exception {
+        runDetectorOnClass(detector, classToTest, bugReporter);
+        asserter.assertAllBugsReported(bugReporter, bugInstanceMatchers);
+    }
+
+    public static void assertBugReported(Class<?> classToTest,
+            Detector2 detector, BugReporter bugReporter) throws Exception {
+        runDetectorOnClass(detector, classToTest, bugReporter);
+        asserter.assertBugReported(bugReporter);
+    }
+
+    public static void assertNoBugsReported(Class<?> classToTest,
+            Detector2 detector, BugReporter bugReporter) throws Exception {
+        runDetectorOnClass(detector, classToTest, bugReporter);
+        asserter.assertNoBugsReported(bugReporter);
+    }
+
+    public static void addRegistarar(IAnalysisEngineRegistrar registrar) {
+        DetectorRunner.addRegistarar(registrar);
+    }
+
+    public static void clearRegistarar() {
+        DetectorRunner.clearRegistarar();
+    }
+
+    private static Detector2 adapt(Detector detector) {
+        return new DetectorToDetector2Adapter(detector);
+    }
 
 }

--- a/src/test/java/com/youdevise/fbplugins/tdd4fb/DetectorRunnerTest.java
+++ b/src/test/java/com/youdevise/fbplugins/tdd4fb/DetectorRunnerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 
@@ -30,7 +31,9 @@ import com.youdevise.fbplugins.tdd4fb.TestingBugReporter;
 
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.Detector;
+import edu.umd.cs.findbugs.Detector2;
 import edu.umd.cs.findbugs.ba.ClassContext;
+import edu.umd.cs.findbugs.classfile.ClassDescriptor;
 
 public class DetectorRunnerTest {
 
@@ -41,6 +44,15 @@ public class DetectorRunnerTest {
 		DetectorRunner.runDetectorOnClass(detector, DetectorRunner.class, bugReporter);
 
 		verify(detector).visitClassContext(argThat(isClassContextFor("DetectorRunner")));
+	}
+
+	@Test public void runDetector2OnClassVisitsDetectorWithClassContextOfSpecifiedClass() throws Exception {
+		Detector2 detector = mock(Detector2.class);
+		BugReporter bugReporter = TestingBugReporter.tddBugReporter();
+
+		DetectorRunner.runDetectorOnClass(detector, DetectorRunner.class, bugReporter);
+
+		verify(detector).visitClass(argThat(isClassDescriptorFor("DetectorRunner")));
 	}
 
 	public static ArgumentMatcher<ClassContext> isClassContextFor(final String simpleClassName) {
@@ -55,4 +67,18 @@ public class DetectorRunnerTest {
 
 		};
 	}
+
+	private Matcher<ClassDescriptor> isClassDescriptorFor(final String simpleClassName) {
+		return new ArgumentMatcher<ClassDescriptor>() {
+			@Override public boolean matches(Object argument) {
+				if (!(argument instanceof ClassDescriptor)) {
+					return false;
+				} else {
+					return ((ClassDescriptor) argument).getSimpleName().equals(simpleClassName);
+				}
+			}
+
+		};
+	}
 }
+


### PR DESCRIPTION
CFG based detector implements Detector2 interface. To test
these detectors, we have to support this interface.

This commit also contains another change: allow user setting original
IAnalysisEngineRegistrar instance. This is also needed to support
test for CFG based detectors.
