### PR TITLE
Suggestion to shorten pom, and skip needless maven-gpg-plugin execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
 	</licenses>
 
 	<scm>
-	
 		<connection>scm:git:git@github.com:youdevise/test-driven-detectors4findbugs.git</connection>
 		<developerConnection>scm:git:git@github.com:youdevise/test-driven-detectors4findbugs.git</developerConnection>
 		<url>git@github.com:youdevise/test-driven-detectors4findbugs.git</url>
@@ -58,7 +57,7 @@
 			<version>1.3.9</version>
 			<scope>compile</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
@@ -79,7 +78,6 @@
 			<version>[4.8,)</version>
 			<scope>test</scope>
 		</dependency>
-		
 	</dependencies>
 
 </project>


### PR DESCRIPTION
When I builded this project, I found that maven-gpg-plugin requests me to input GPG passphrase.
I felt little troublesome, because what I need is not deploy but just building product.

The [oss-parent project](https://github.com/sonatype/oss-parents/blob/oss-parent-7/pom.xml) provides `sonatype-oss-release` profile to sign jar file, and this profile will be activated when we execute `maven-release-plugin` like `mvn release:prepare`. So we do not have to make original profile.

See also: http://lacostej.blogspot.jp/2011/01/publishing-your-signed-oss-project-to.html
