### PR TITLE
Assertions on list of bug instances

### DIFF
--- a/src/main/java/com/youdevise/fbplugins/tdd4fb/BugsReportedAsserter.java
+++ b/src/main/java/com/youdevise/fbplugins/tdd4fb/BugsReportedAsserter.java
@@ -20,6 +20,7 @@ package com.youdevise.fbplugins.tdd4fb;
 
 import static org.hamcrest.CoreMatchers.is;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.hamcrest.Description;
@@ -47,6 +48,12 @@ class BugsReportedAsserter {
 	public void assertBugReported(BugReporter bugReporter, Matcher<BugInstance> matches) {
 		Collection<BugInstance> bugsReported = bugsFrom(bugReporter);
 		assertThat(bugsReported, Matchers.<BugInstance>hasItem(matches));
+	}
+
+	public void assertBugsReported(BugReporter bugReporter, Matcher<Iterable<Object>> listMatcher) {
+		Collection<BugInstance> bugsReported = bugsFrom(bugReporter);
+		Iterable<Object> i = Arrays.asList(bugsReported.toArray());
+		assertThat(i, listMatcher);
 	}
 
 	public void assertAllBugsReported(BugReporter bugReporter, Matcher<BugInstance>... matches) {

--- a/src/main/java/com/youdevise/fbplugins/tdd4fb/DetectorAssert.java
+++ b/src/main/java/com/youdevise/fbplugins/tdd4fb/DetectorAssert.java
@@ -63,6 +63,21 @@ public class DetectorAssert {
         asserter.assertBugReported(bugReporter, bugInstanceMatcher);
     }
 
+    public static void assertBugsReported(Class<?> classToTest,
+                                          Detector detector,
+                                          BugReporter bugReporter,
+                                          Matcher<Iterable<Object>> iterableMatcher) throws Exception {
+        assertBugsReported(classToTest, adapt(detector), bugReporter, iterableMatcher);
+    }
+
+    public static void assertBugsReported(Class<?> classToTest,
+                                          Detector2 detector,
+                                          BugReporter bugReporter,
+                                          Matcher<Iterable<Object>> iterableMatcher) throws Exception {
+        detectorRunner.runDetectorOnClass(detector, classToTest, bugReporter);
+        asserter.assertBugsReported(bugReporter, iterableMatcher);
+    }
+
     public static void assertAllBugsReported(Class<?> classToTest,
                                              Detector detector,
                                              BugReporter bugReporter,

--- a/src/test/java/com/youdevise/fbplugins/tdd4fb/DetectorAssertTest.java
+++ b/src/test/java/com/youdevise/fbplugins/tdd4fb/DetectorAssertTest.java
@@ -35,6 +35,10 @@ import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.Priorities;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.iterableWithSize;
+
 public class DetectorAssertTest {
 	
 	private BugReporter bugReporter;
@@ -65,7 +69,13 @@ public class DetectorAssertTest {
 		bugReporter.reportBug(bugInstance);
 		asserter.assertBugReported(bugReporter);
 	}
-	
+
+	@Test public void
+	assertBugsReportedPassesTestWhenAnyBugIsReported() {
+		bugReporter.reportBug(bugInstance);
+		asserter.assertBugsReported(bugReporter, allOf(iterableWithSize(greaterThan(0))));
+	}
+
 	@Test(expected=AssertionError.class) public void
 	assertBugReportedFailsTestWhenNoBugIsReported() {
 		 // don't report a bug


### PR DESCRIPTION
Adds methods to assert against the list of bug instances with Hamcrest matchers, e.g. to assert length to assert number of bugs reported.